### PR TITLE
bug-fix: no more overlapping in small devices

### DIFF
--- a/src/components/menu/index.tsx
+++ b/src/components/menu/index.tsx
@@ -96,12 +96,12 @@ export default function Menu() {
       <Glow className="sm:right-0 sm:max-w-3xl " />
       <Container className="relative z-0 flex min-h-[4rem] flex-col items-center  justify-end sm:min-h-[5rem] sm:flex-row sm:justify-between">
         {/* upper section */}
-        <div className="flex items-center gap-x-12">
+        <div className="z-10 flex items-center gap-x-12">
           {displayLogo}
           {displayIcon}
         </div>
         {/* links section */}
-        <div className="sm:self-end">
+        <div className="z-0 sm:self-end">
           <MenuList />
         </div>
       </Container>

--- a/src/components/menu/menu-list.tsx
+++ b/src/components/menu/menu-list.tsx
@@ -1,10 +1,12 @@
 import { links } from '@/data/menu-links';
+import useArea from '@/hooks/useArea';
 import SmoothLink from '@utilities/SmoothLink';
 import ToolTip from '@utilities/tooltip';
 import { useRouter } from 'next/router';
 
 export default function MenuList() {
   const { pathname } = useRouter();
+  const { width } = useArea();
   return (
     <ul className="flex items-center ">
       {links.map((link, indx) => {
@@ -28,7 +30,10 @@ export default function MenuList() {
             hover:text-accent            
             `}
           >
-            <ToolTip tip={link.title}>
+            <ToolTip
+              direction={width < 640 ? `button` : `top`}
+              tip={link.title}
+            >
               <link.icon className="h-6 w-6" />
             </ToolTip>
           </li>
@@ -50,7 +55,10 @@ export default function MenuList() {
               hover:text-accent
             `}
             >
-              <ToolTip tip={link.title}>
+              <ToolTip
+                direction={width < 640 ? `button` : `top`}
+                tip={link.title}
+              >
                 <link.icon className="h-6 w-6" />
               </ToolTip>
             </li>

--- a/src/components/navbar/theme-button.tsx
+++ b/src/components/navbar/theme-button.tsx
@@ -7,7 +7,7 @@ export default function ThemeButton() {
   const { isDark } = useThemeContext();
   return (
     <div className="">
-      <Pop Icon={isDark ? MoonIcon : SunIcon} className="!z-50">
+      <Pop Icon={isDark ? MoonIcon : SunIcon} className="z-50">
         <Themes />
       </Pop>
     </div>

--- a/src/components/utilities/tooltip.tsx
+++ b/src/components/utilities/tooltip.tsx
@@ -2,16 +2,26 @@ import { ComponentProps, FC } from 'react';
 
 type ToolTipProps = ComponentProps<'div'> & {
   tip: string;
+  direction?: 'top' | 'button';
 };
 
-const ToolTip: FC<ToolTipProps> = ({ tip, ...props }) => {
+const ToolTip: FC<ToolTipProps> = ({ tip, direction = 'top', ...props }) => {
   return (
     <div className="group relative z-10">
       <div {...props} />
-      <span className="absolute left-1/2 -top-12 hidden h-fit w-fit -translate-x-1/2 whitespace-nowrap rounded-md bg-skin-inverted px-4 py-1 text-sm font-medium text-skin-inverted transition-all duration-200 ease-in-out group-hover:block">
+      <span
+        className={`absolute left-1/2  hidden h-fit w-fit -translate-x-1/2 whitespace-nowrap rounded-md bg-skin-inverted px-4 py-1 text-sm font-medium text-skin-inverted transition-all duration-200 ease-in-out group-hover:block
+      ${direction === 'top' ? `-top-12` : `-bottom-12`}
+      
+      `}
+      >
         {tip}
 
-        <span className="absolute left-1/2 -bottom-1 -z-10 h-4 w-4 -translate-x-1/2 rotate-45 rounded bg-skin-inverted"></span>
+        <span
+          className={`absolute left-1/2  -z-10 h-4 w-4 -translate-x-1/2 rotate-45 rounded bg-skin-inverted
+        ${direction === 'top' ? `-bottom-1` : `-top-1`}
+        `}
+        ></span>
       </span>
     </div>
   );

--- a/src/hooks/useArea.ts
+++ b/src/hooks/useArea.ts
@@ -1,0 +1,27 @@
+import { useEffect, useState } from 'react';
+
+const useArea = (): {
+  width: number;
+  height: number;
+} => {
+  const [width, setWidth] = useState<number>(0);
+  const [height, setHeight] = useState<number>(0);
+
+  useEffect(() => {
+    setWidth(window.innerWidth);
+    setHeight(window.innerHeight);
+
+    function calcArea() {
+      setWidth(window.innerWidth);
+      setHeight(window.innerHeight);
+    }
+
+    window.addEventListener('resize', calcArea);
+
+    return () => window.removeEventListener('resize', calcArea);
+  }, []);
+
+  return { width, height };
+};
+
+export default useArea;


### PR DESCRIPTION
#### Fixes
- Menu icons were overlapping while clicking on the theme change icon
- Enabled tool-tip view in top and bottom as well
- Added a custom hook that calculates width and height of the view-port that's crucial for conditional tip view