### PR TITLE
fix: active links are persistent and does not get reset on reload

### DIFF
--- a/src/components/guidespage/SubLinks.tsx
+++ b/src/components/guidespage/SubLinks.tsx
@@ -11,7 +11,6 @@ type SubLinksProps = {
 
 const SubLinks: FC<SubLinksProps> = ({ fileList, onLinkClick }) => {
   const { activeLink, setActiveLink } = useDocumentationContext();
-  console.log(activeLink);
 
   fileList = [
     ...fileList.filter((file) => file.name === 'welcome'),

--- a/src/context/DocumentationContext.tsx
+++ b/src/context/DocumentationContext.tsx
@@ -7,7 +7,6 @@ import {
   SetStateAction,
   createContext,
   useContext,
-  useEffect,
   useState,
 } from 'react';
 
@@ -36,12 +35,7 @@ type DocumentationProps = {
 // Context Provider
 const DocumentationProvider: FC<DocumentationProps> = ({ children }) => {
   const [isSidebarOpen, setIsSidebarOpen] = useState<boolean>(false);
-  const [activeLink, setActiveLink] = useState<PostFile['link']>(``);
-
-  useEffect(() => {
-    setActiveLink(links[2].to);
-    return () => setActiveLink(``);
-  }, []);
+  const [activeLink, setActiveLink] = useState<PostFile['link']>(links[2].to);
 
   // Functions...
   function openSidebar() {

--- a/src/layouts/DocumentationLayout.tsx
+++ b/src/layouts/DocumentationLayout.tsx
@@ -44,7 +44,8 @@ const DocumentationLayout: FC<DocumentationLayoutProps> = ({
                   {width < 1024 && <DocList mobile data={menu} />}
                   <BreadCrumb dirName={meta.dirName} fileName={meta.fileName} />
                 </div>
-                <a href={meta.edit}>
+                {/* edit on github */}
+                <a href={meta.edit} target="_blank" rel="noreferrer">
                   <ToolTip tip="Edit on Github" direction="button">
                     <DocEditIcon className="h-6 w-6" />
                   </ToolTip>

--- a/src/pages/guides/[...guide].tsx
+++ b/src/pages/guides/[...guide].tsx
@@ -1,5 +1,6 @@
 import mdxComponents from '@/components/mdxcomponents';
 import TypoComp from '@/components/utilities/TypoComponent';
+import { useDocumentationContext } from '@/context/DocumentationContext';
 import Container from '@/layouts/Container';
 import DocumentationLayout from '@/layouts/DocumentationLayout';
 import {
@@ -10,12 +11,22 @@ import {
 import type { FolderStructure, Post } from '@/types/client/FileSystem';
 import type { GetStaticPaths, GetStaticProps, NextPage } from 'next';
 import { MDXRemote } from 'next-mdx-remote';
+import { useEffect } from 'react';
 
 type DocsProps = Post & {
   menu: FolderStructure;
+  activeLink: string;
 };
 
-const Guides: NextPage<DocsProps> = ({ menu, meta, source }) => {
+const Guides: NextPage<DocsProps> = ({ activeLink, menu, meta, source }) => {
+  const { setActiveLink } = useDocumentationContext();
+
+  useEffect(() => {
+    setActiveLink(`/guides/${activeLink}`);
+
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [activeLink]);
+
   return (
     <DocumentationLayout menu={menu} meta={meta} className="text-skin-base">
       <Container className="relative py-4">
@@ -44,13 +55,15 @@ export const getStaticProps: GetStaticProps<DocsProps> = async ({ params }) => {
     const menu = await getDocumentsMenu();
 
     const { guide } = params as { guide: string[] };
-    const { meta, source } = await getContentsFromSlug(guide.join('/'));
+    const activeLink = guide.join('/');
+    const { meta, source } = await getContentsFromSlug(activeLink);
 
     return {
       props: {
         meta,
         source,
         menu,
+        activeLink,
       },
     };
   } catch (error) {


### PR DESCRIPTION
<!-- If your PR fixes an open issue, use `Closes #999` to link your PR with the issue. #999 stands for the issue number you are fixing -->

## Fixes Issue
This pr fixes sidebar reset issue on reload. Sidebar link highlighting is now persisted to respective page.
<!-- Example: Closes #31 -->
Closes #54 

## Changes proposed
- Added a active link to track active page
- Active link is set as documentation context
- Matched active link with file link to highlight the right one
<!-- List all the proposed changes in your PR -->

## Screenshots
N/A
<!-- Add all the screenshots which support your changes -->

## Note to reviewers
N/A
<!-- Add notes to reviewers if applicable -->
